### PR TITLE
Add net/context helper.

### DIFF
--- a/log.go
+++ b/log.go
@@ -165,6 +165,10 @@ func LogFromContext(c context.Context) Logger {
 	return logger
 }
 
+func SaveToContext(l Logger, base context.Context) context.Context {
+	return context.WithValue(base, contextKey, l)
+}
+
 func (l Logger) makeCopy() Logger {
 	newLogger := l
 	newLogger.buf = nil

--- a/log.go
+++ b/log.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/DramaFever/raven-go"
 )
 
@@ -22,6 +24,8 @@ const (
 	WarnLvl Level = "WARN"
 	// ErrorLvl indicates non-recoverable error messages
 	ErrorLvl Level = "ERROR"
+
+	contextKey = "github.com/DramaFever/go-logging#Logger"
 )
 
 // Level is a threshold used to constrain which logs are written in which environments.
@@ -139,6 +143,26 @@ func New(level Level, out io.Writer, sentry string, sentryTags map[string]string
 		flock:  new(sync.Mutex),
 		tags:   map[string]string{},
 	}, err
+}
+
+func LogFromContext(c context.Context) Logger {
+	ctxVal := c.Value(contextKey)
+	if ctxVal == nil {
+		logger, err := New(InfoLvl, os.Stderr, "", nil)
+		if err != nil {
+			panic(err.Error())
+		}
+		return logger
+	}
+	logger, ok := ctxVal.(Logger)
+	if !ok {
+		logger, err := New(InfoLvl, os.Stderr, "", nil)
+		if err != nil {
+			panic(err.Error())
+		}
+		return logger
+	}
+	return logger
 }
 
 func (l Logger) makeCopy() Logger {

--- a/log.go
+++ b/log.go
@@ -145,6 +145,12 @@ func New(level Level, out io.Writer, sentry string, sentryTags map[string]string
 	}, err
 }
 
+// LogFromContext returns a Logger that is ready to use from the Context provided. In a case where a Logger
+// has not been stored in the Context previously (using SaveToContext), LogFromContext will fall back on a
+// Logger that writes to stderr, is set to InfoLvl, and has no Sentry configuration. This is to help debug
+// Logger configuration errors; in production, SaveToContext should always be used before trying to retrieve
+// the Logger wtih LogFromContext. Normally, SaveToContext should be called as part of application startup
+// when the Logger is instantiated.
 func LogFromContext(c context.Context) Logger {
 	ctxVal := c.Value(contextKey)
 	if ctxVal == nil {
@@ -165,6 +171,9 @@ func LogFromContext(c context.Context) Logger {
 	return logger
 }
 
+// SaveToContext adds a Logger to the supplied Context, returning the new Context that contains the Logger.
+// SaveToContext should generally be called during application startup, when the Logger is instantiated. Once
+// a Logger is stored with SaveToContext, it can be retrieved using LogFromContext.
 func SaveToContext(l Logger, base context.Context) context.Context {
 	return context.WithValue(base, contextKey, l)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -156,7 +156,7 @@ func TestOutput(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 462
+	line := 471
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 457
@@ -204,7 +204,7 @@ func TestHelpers(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 396
+	line := 405
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 392
@@ -231,7 +231,7 @@ func TestHelpers(t *testing.T) {
 			t.Errorf("Unexpected level: %s\n", test.stmtLevel)
 		}
 		f("Test number", pos)
-		line = 396
+		line = 405
 		if testing.Coverage() > 0 {
 			line = 392
 		}
@@ -247,7 +247,7 @@ func TestHelpers(t *testing.T) {
 
 		buf.Reset()
 		ff("Test number %d", pos)
-		line = 403
+		line = 412
 		if testing.Coverage() > 0 {
 			line = 401
 		}

--- a/log_test.go
+++ b/log_test.go
@@ -156,10 +156,10 @@ func TestOutput(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 458
+	line := 462
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
-		line = 452
+		line = 457
 	}
 	expected := fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s\n", year, month, day, hour, minute, second, InfoLvl, path, line, "My test output")
 	if buf.String() != expected {
@@ -204,10 +204,10 @@ func TestHelpers(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 392
+	line := 396
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
-		line = 386
+		line = 392
 	}
 	for pos, test := range levelTests {
 		buf.Reset()
@@ -231,9 +231,9 @@ func TestHelpers(t *testing.T) {
 			t.Errorf("Unexpected level: %s\n", test.stmtLevel)
 		}
 		f("Test number", pos)
-		line = 392
+		line = 396
 		if testing.Coverage() > 0 {
-			line = 387
+			line = 392
 		}
 		var expectation string
 		if test.includes {
@@ -247,9 +247,9 @@ func TestHelpers(t *testing.T) {
 
 		buf.Reset()
 		ff("Test number %d", pos)
-		line = 399
+		line = 403
 		if testing.Coverage() > 0 {
-			line = 396
+			line = 401
 		}
 		if test.includes {
 			expectation = fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s %d\n", year, month, day, hour, minute, second, test.stmtLevel, path, line, "Test number", pos)

--- a/log_test.go
+++ b/log_test.go
@@ -156,10 +156,10 @@ func TestOutput(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 434
+	line := 458
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
-		line = 419
+		line = 452
 	}
 	expected := fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s\n", year, month, day, hour, minute, second, InfoLvl, path, line, "My test output")
 	if buf.String() != expected {
@@ -204,7 +204,7 @@ func TestHelpers(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 368
+	line := 392
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 386
@@ -231,9 +231,9 @@ func TestHelpers(t *testing.T) {
 			t.Errorf("Unexpected level: %s\n", test.stmtLevel)
 		}
 		f("Test number", pos)
-		line = 368
+		line = 392
 		if testing.Coverage() > 0 {
-			line = 354
+			line = 387
 		}
 		var expectation string
 		if test.includes {
@@ -247,9 +247,9 @@ func TestHelpers(t *testing.T) {
 
 		buf.Reset()
 		ff("Test number %d", pos)
-		line = 375
+		line = 399
 		if testing.Coverage() > 0 {
-			line = 363
+			line = 396
 		}
 		if test.includes {
 			expectation = fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s %d\n", year, month, day, hour, minute, second, test.stmtLevel, path, line, "Test number", pos)


### PR DESCRIPTION
We want to be able to easily grab a logger from the
golang.org/x/net/context#Context type we're passing around. Rather than
implementing it in each and every application, I thought it made sense
to have a helper in the logging package itself that had a sane default
behaviour.