### PR TITLE
Log rotation

### DIFF
--- a/log.go
+++ b/log.go
@@ -53,7 +53,7 @@ const (
 type Level string
 
 // We need a static list of rotatable loggers for when SIGUSR1 is caught
-var rotatableLoggers *list.List = list.New()
+var rotatableLoggers = list.New()
 
 // Start up a goroutine to catch SIGUSR1.
 func init() {

--- a/log_test.go
+++ b/log_test.go
@@ -156,7 +156,7 @@ func TestOutput(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 471
+	line := 537
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 457
@@ -204,7 +204,7 @@ func TestHelpers(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 405
+	line := 471
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 392
@@ -231,7 +231,7 @@ func TestHelpers(t *testing.T) {
 			t.Errorf("Unexpected level: %s\n", test.stmtLevel)
 		}
 		f("Test number", pos)
-		line = 405
+		line = 471
 		if testing.Coverage() > 0 {
 			line = 392
 		}
@@ -247,7 +247,7 @@ func TestHelpers(t *testing.T) {
 
 		buf.Reset()
 		ff("Test number %d", pos)
-		line = 412
+		line = 478
 		if testing.Coverage() > 0 {
 			line = 401
 		}
@@ -259,5 +259,29 @@ func TestHelpers(t *testing.T) {
 		if buf.String() != expectation {
 			t.Errorf("Expected `%s`, got `%s` from %#+v\n", expectation, buf.String(), test)
 		}
+	}
+}
+
+func TestRotatableLoggers(t *testing.T) {
+	New(InfoLvl, os.Stdout, "sentry", nil)
+	if rotatableLoggers.Front() != nil {
+		t.Error("There should be no elements in rotatableLoggers at this point.")
+	}
+
+	l, err1 := LogToDir(InfoLvl, "./", "foo", "", nil)
+	if err1 != nil {
+		panic(err1.Error())
+	}
+	logFileName := l.logFile.Name()
+
+	if rotatableLoggers.Front() == nil {
+		t.Error("There should be an element in rotatableLoggers at this point.")
+	}
+
+	l.Close()
+	err := os.Remove(logFileName)
+
+	if err != nil {
+		t.Errorf("Error removing %s : %s", logFileName, err.Error())
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -159,7 +159,7 @@ func TestOutput(t *testing.T) {
 	line := 548
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
-		line = 457
+		line = 665
 	}
 	expected := fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s\n", year, month, day, hour, minute, second, InfoLvl, path, line, "My test output")
 	if buf.String() != expected {
@@ -207,7 +207,7 @@ func TestHelpers(t *testing.T) {
 	line := 482
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
-		line = 392
+		line = 589
 	}
 	for pos, test := range levelTests {
 		buf.Reset()
@@ -233,7 +233,7 @@ func TestHelpers(t *testing.T) {
 		f("Test number", pos)
 		line = 482
 		if testing.Coverage() > 0 {
-			line = 392
+			line = 589
 		}
 		var expectation string
 		if test.includes {
@@ -249,7 +249,7 @@ func TestHelpers(t *testing.T) {
 		ff("Test number %d", pos)
 		line = 489
 		if testing.Coverage() > 0 {
-			line = 401
+			line = 598
 		}
 		if test.includes {
 			expectation = fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s %d\n", year, month, day, hour, minute, second, test.stmtLevel, path, line, "Test number", pos)

--- a/log_test.go
+++ b/log_test.go
@@ -270,7 +270,7 @@ func TestRotatableLoggers(t *testing.T) {
 
 	l, err1 := LogToDir(InfoLvl, "./", "foo", "", nil)
 	if err1 != nil {
-		panic(err1.Error())
+		t.Errorf("Something went wrong with LogToDir. %s", err1.Error())
 	}
 	logFileName := l.logFile.Name()
 

--- a/log_test.go
+++ b/log_test.go
@@ -156,7 +156,7 @@ func TestOutput(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 537
+	line := 548
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 457
@@ -204,7 +204,7 @@ func TestHelpers(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	path := strings.TrimRight(os.Getenv("GOPATH"), "/") + "/src/github.com/DramaFever/go-logging/log.go"
-	line := 471
+	line := 482
 	if testing.Coverage() > 0 {
 		path = "github.com/DramaFever/go-logging/_test/_obj_test/log.go"
 		line = 392
@@ -231,7 +231,7 @@ func TestHelpers(t *testing.T) {
 			t.Errorf("Unexpected level: %s\n", test.stmtLevel)
 		}
 		f("Test number", pos)
-		line = 471
+		line = 482
 		if testing.Coverage() > 0 {
 			line = 392
 		}
@@ -247,7 +247,7 @@ func TestHelpers(t *testing.T) {
 
 		buf.Reset()
 		ff("Test number %d", pos)
-		line = 478
+		line = 489
 		if testing.Coverage() > 0 {
 			line = 401
 		}


### PR DESCRIPTION
Adds support for log rotation per the DramaFever tech handbook

When a program implements go-logging and uses the `LogToDir` function to create a new Logger, a log file will be created in a specified directory using a specified base name and the datetime at which the log file was created. LogRotate can then send that program a SIGUSR1. SIGUSR1 will be caught by go-logging, which will automagically create a new logfile using the base name, directory, and the current datetime. The Logger will then log to the new file, all transparent to the program implementing go-logging.