### PR TITLE
Update our context for go 1.7

### DIFF
--- a/context17.go
+++ b/context17.go
@@ -1,0 +1,41 @@
+// +build go1.7
+
+package logging
+
+import (
+	"context"
+	"os"
+)
+
+// LogFromContext returns a Logger that is ready to use from the Context provided. In a case where a Logger
+// has not been stored in the Context previously (using SaveToContext), LogFromContext will fall back on a
+// Logger that writes to stderr, is set to InfoLvl, and has no Sentry configuration. This is to help debug
+// Logger configuration errors; in production, SaveToContext should always be used before trying to retrieve
+// the Logger wtih LogFromContext. Normally, SaveToContext should be called as part of application startup
+// when the Logger is instantiated.
+func LogFromContext(c context.Context) Logger {
+	ctxVal := c.Value(contextKey)
+	if ctxVal == nil {
+		logger, err := New(InfoLvl, os.Stderr, "", nil)
+		if err != nil {
+			panic(err.Error())
+		}
+		return logger
+	}
+	logger, ok := ctxVal.(Logger)
+	if !ok {
+		logger, err := New(InfoLvl, os.Stderr, "", nil)
+		if err != nil {
+			panic(err.Error())
+		}
+		return logger
+	}
+	return logger
+}
+
+// SaveToContext adds a Logger to the supplied Context, returning the new Context that contains the Logger.
+// SaveToContext should generally be called during application startup, when the Logger is instantiated. Once
+// a Logger is stored with SaveToContext, it can be retrieved using LogFromContext.
+func SaveToContext(l Logger, base context.Context) context.Context {
+	return context.WithValue(base, contextKey, l)
+}

--- a/contextpre17.go
+++ b/contextpre17.go
@@ -1,0 +1,41 @@
+// +build !go1.7
+
+package logging
+
+import (
+	"context"
+	"os"
+)
+
+// LogFromContext returns a Logger that is ready to use from the Context provided. In a case where a Logger
+// has not been stored in the Context previously (using SaveToContext), LogFromContext will fall back on a
+// Logger that writes to stderr, is set to InfoLvl, and has no Sentry configuration. This is to help debug
+// Logger configuration errors; in production, SaveToContext should always be used before trying to retrieve
+// the Logger wtih LogFromContext. Normally, SaveToContext should be called as part of application startup
+// when the Logger is instantiated.
+func LogFromContext(c context.Context) Logger {
+	ctxVal := c.Value(contextKey)
+	if ctxVal == nil {
+		logger, err := New(InfoLvl, os.Stderr, "", nil)
+		if err != nil {
+			panic(err.Error())
+		}
+		return logger
+	}
+	logger, ok := ctxVal.(Logger)
+	if !ok {
+		logger, err := New(InfoLvl, os.Stderr, "", nil)
+		if err != nil {
+			panic(err.Error())
+		}
+		return logger
+	}
+	return logger
+}
+
+// SaveToContext adds a Logger to the supplied Context, returning the new Context that contains the Logger.
+// SaveToContext should generally be called during application startup, when the Logger is instantiated. Once
+// a Logger is stored with SaveToContext, it can be retrieved using LogFromContext.
+func SaveToContext(l Logger, base context.Context) context.Context {
+	return context.WithValue(base, contextKey, l)
+}

--- a/log.go
+++ b/log.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/getsentry/raven-go"
 )
 
@@ -143,39 +141,6 @@ func New(level Level, out io.Writer, sentry string, sentryTags map[string]string
 		flock:  new(sync.Mutex),
 		tags:   map[string]string{},
 	}, err
-}
-
-// LogFromContext returns a Logger that is ready to use from the Context provided. In a case where a Logger
-// has not been stored in the Context previously (using SaveToContext), LogFromContext will fall back on a
-// Logger that writes to stderr, is set to InfoLvl, and has no Sentry configuration. This is to help debug
-// Logger configuration errors; in production, SaveToContext should always be used before trying to retrieve
-// the Logger wtih LogFromContext. Normally, SaveToContext should be called as part of application startup
-// when the Logger is instantiated.
-func LogFromContext(c context.Context) Logger {
-	ctxVal := c.Value(contextKey)
-	if ctxVal == nil {
-		logger, err := New(InfoLvl, os.Stderr, "", nil)
-		if err != nil {
-			panic(err.Error())
-		}
-		return logger
-	}
-	logger, ok := ctxVal.(Logger)
-	if !ok {
-		logger, err := New(InfoLvl, os.Stderr, "", nil)
-		if err != nil {
-			panic(err.Error())
-		}
-		return logger
-	}
-	return logger
-}
-
-// SaveToContext adds a Logger to the supplied Context, returning the new Context that contains the Logger.
-// SaveToContext should generally be called during application startup, when the Logger is instantiated. Once
-// a Logger is stored with SaveToContext, it can be retrieved using LogFromContext.
-func SaveToContext(l Logger, base context.Context) context.Context {
-	return context.WithValue(base, contextKey, l)
 }
 
 func (l Logger) makeCopy() Logger {

--- a/log_test.go
+++ b/log_test.go
@@ -179,9 +179,9 @@ func TestOutput(t *testing.T) {
 	year, month, day := time.Now().Date()
 	hour, minute, second := time.Now().Clock()
 	file := getFilePath()
-	line := 472
+	line := 437
 	if testing.Coverage() > 0 {
-		line = 577
+		line = 532
 	}
 	expected := fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s\n", year, month, day, hour, minute, second, InfoLvl, file, line, "My test output")
 	if buf.String() != expected {
@@ -252,9 +252,9 @@ func TestHelpers(t *testing.T) {
 			t.Errorf("Unexpected level: %s\n", test.stmtLevel)
 		}
 		f("Test number", pos)
-		line = 406
+		line = 371
 		if testing.Coverage() > 0 {
-			line = 501
+			line = 456
 		}
 		var expectation string
 		if test.includes {
@@ -268,9 +268,9 @@ func TestHelpers(t *testing.T) {
 
 		buf.Reset()
 		ff("Test number %d", pos)
-		line = 413
+		line = 378
 		if testing.Coverage() > 0 {
-			line = 510
+			line = 465
 		}
 		if test.includes {
 			expectation = fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d [%s] %s:%d: %s %d\n", year, month, day, hour, minute, second, test.stmtLevel, file, line, "Test number", pos)


### PR DESCRIPTION
When building with go 1.7, use the standard library's context package.
For packages below 1.7, use the golang.org/x/net/context package.
